### PR TITLE
Make code block line numbers follow markup.highlight.lineNos config

### DIFF
--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,6 +1,6 @@
 {{- $lang := .Type -}}
 {{- $code := .Inner -}}
-{{- $options := dict "lineNos" true "style" "github-dark" -}}
+{{- $options := dict "style" "github-dark" -}}
 {{- if $lang -}}
 {{- $highlighted := transform.Highlight $code $lang $options -}}
 {{- /* Replace language- with syntax- to avoid 1Password selector */ -}}


### PR DESCRIPTION
## Summary
- `render-codeblock.html` hardcoded `lineNos=true` in the options passed to `transform.Highlight`, which overrode the site's `markup.highlight.lineNos` config (set to `false`) and forced line numbers on every syntax-highlighted code block.
- Removing the `lineNos` key lets `transform.Highlight` fall back to the site config value, so line numbers are now controlled solely by `config/_default/config.toml`'s `markup.highlight.lineNos`.

## Test plan
- [x] `hugo` build with `markup.highlight.lineNos = false` (current config) → rendered code blocks have no `<table class="lntable">` line-number markup
- [x] Temporarily flipped `lineNos = true` in config and rebuilt → line-number table appeared, confirming the value is now inherited from config
- [x] Reverted config back to `false`, rebuilt again → no line numbers, matching intended default

🤖 Generated with [Claude Code](https://claude.com/claude-code)